### PR TITLE
Add conda build scripts (fixes #49)

### DIFF
--- a/maintainer/conda/asciitree/bld.bat
+++ b/maintainer/conda/asciitree/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/maintainer/conda/asciitree/build.sh
+++ b/maintainer/conda/asciitree/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/maintainer/conda/asciitree/meta.yaml
+++ b/maintainer/conda/asciitree/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: asciitree
+  version: "0.3.1"
+
+source:
+  fn: asciitree-0.3.1.tar.gz
+  url: https://pypi.python.org/packages/source/a/asciitree/asciitree-0.3.1.tar.gz
+  md5: c0fdd1583971b63b4aa36b7425cbe3c5
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - asciitree = asciitree:main
+    #
+    # Would create an entry point called asciitree that calls asciitree.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - asciitree
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://github.com/mbr/asciitree
+  license: MIT
+  summary: 'Draws ASCII trees.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/maintainer/conda/datreant.core/bld.bat
+++ b/maintainer/conda/datreant.core/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/maintainer/conda/datreant.core/build.sh
+++ b/maintainer/conda/datreant.core/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pip install pathlib
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/maintainer/conda/datreant.core/meta.yaml
+++ b/maintainer/conda/datreant.core/meta.yaml
@@ -1,0 +1,85 @@
+package:
+  name: datreant.core
+  version: "0.6.0"
+
+source:
+  fn: datreant.core-0.6.0.tar.gz
+  url: https://pypi.python.org/packages/source/d/datreant.core/datreant.core-0.6.0.tar.gz
+  md5: 0789978ccac2ca2d8a08a80db9dfcdeb
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - datreant.core = datreant.core:main
+    #
+    # Would create an entry point called datreant.core that calls datreant.core.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - pip
+    - setuptools
+    - asciitree
+    - pathlib
+    - scandir
+    - six
+    - fuzzywuzzy
+    - pytest
+
+  run:
+    - python
+    - asciitree
+    - pathlib
+    - scandir
+    - six
+    - fuzzywuzzy
+    - pytest
+
+test:
+  # Python imports
+  imports:
+    - datreant
+    - datreant.core
+    - datreant.core.backends
+    - datreant.core.tests
+
+  requires:
+    # Put any additional test requirements here.  For example
+    - pytest
+    - python
+    - asciitree
+    - pathlib
+    - scandir
+    - six
+    - fuzzywuzzy
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+    # - py.test src/datreant
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+
+about:
+  home: http://datreant.org/
+  license: BSD License
+  summary: 'persistent, pythonic trees for heterogeneous data'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/maintainer/conda/fuzzywuzzy/bld.bat
+++ b/maintainer/conda/fuzzywuzzy/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/maintainer/conda/fuzzywuzzy/build.sh
+++ b/maintainer/conda/fuzzywuzzy/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/maintainer/conda/fuzzywuzzy/meta.yaml
+++ b/maintainer/conda/fuzzywuzzy/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: fuzzywuzzy
+  version: "0.10.0"
+
+source:
+  fn: fuzzywuzzy-0.10.0.tar.gz
+  url: https://pypi.python.org/packages/source/f/fuzzywuzzy/fuzzywuzzy-0.10.0.tar.gz
+  md5: a778229e1362dd8cb7626e21303552e3
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - fuzzywuzzy = fuzzywuzzy:main
+    #
+    # Would create an entry point called fuzzywuzzy that calls fuzzywuzzy.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - fuzzywuzzy
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/seatgeek/fuzzywuzzy
+  license: 
+  summary: 'Fuzzy string matching in python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/maintainer/conda/pathlib/bld.bat
+++ b/maintainer/conda/pathlib/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/maintainer/conda/pathlib/build.sh
+++ b/maintainer/conda/pathlib/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/maintainer/conda/pathlib/meta.yaml
+++ b/maintainer/conda/pathlib/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: pathlib
+  version: "1.0.1"
+
+source:
+  fn: pathlib-1.0.1.tar.gz
+  url: https://pypi.python.org/packages/source/p/pathlib/pathlib-1.0.1.tar.gz
+  md5: 5099ed48be9b1ee29b31c82819240537
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - pathlib = pathlib:main
+    #
+    # Would create an entry point called pathlib that calls pathlib.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - pathlib
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://pathlib.readthedocs.org/
+  license: MIT License
+  summary: 'Object-oriented filesystem paths'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/maintainer/conda/scandir/bld.bat
+++ b/maintainer/conda/scandir/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/maintainer/conda/scandir/build.sh
+++ b/maintainer/conda/scandir/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/maintainer/conda/scandir/meta.yaml
+++ b/maintainer/conda/scandir/meta.yaml
@@ -1,0 +1,59 @@
+package:
+  name: scandir
+  version: "1.2"
+
+source:
+  fn: scandir-1.2.tar.gz
+  url: https://pypi.python.org/packages/source/s/scandir/scandir-1.2.tar.gz
+  md5: 3a317b482128e072f6cfb3bb2ce52e06
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - scandir = scandir:main
+    #
+    # Would create an entry point called scandir that calls scandir.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+# test:
+  # Python imports
+  # imports:
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/benhoyt/scandir
+  license: BSD License
+  summary: 'scandir, a better directory iterator and faster os.walk()'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
See #49

Adds build scripts for all dependencies as well. This doesn't work completely as I would like it yet. For some reason I have to pip install `pathlib` even though I have installed a conda package for it. I'm not sure that that means currently.

A way to run the test from a installed version of datreant would be nice as well.