### PR TITLE
We now use pathlib2 as a dependency instead of pathlib.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,8 @@ Fixes
 
 Changes
 
+    * Switched from ``pathlib`` to ``pathlib2`` as a dependency for backwards
+      compatibility with python < 3.4.
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(name='datreant.core',
       scripts=[],
       license='BSD',
       long_description=open('README.rst').read(),
-      install_requires=['asciitree', 'pathlib', 'scandir', 'six', 'fuzzywuzzy']
+      install_requires=['asciitree', 'pathlib2', 'scandir', 'six', 'fuzzywuzzy']
       )

--- a/src/datreant/core/treants.py
+++ b/src/datreant/core/treants.py
@@ -6,7 +6,7 @@ import os
 import functools
 import six
 from uuid import uuid4
-from pathlib import Path
+from pathlib2 import Path
 
 from . import limbs
 from . import filesystem
@@ -316,7 +316,7 @@ class Treant(six.with_metaclass(_Treantmeta, Tree)):
 
     @property
     def path(self):
-        """Treant directory as a :class:`pathlib.Path`.
+        """Treant directory as a :class:`pathlib2.Path`.
 
         """
         return Path(self._backend.get_location())

--- a/src/datreant/core/trees.py
+++ b/src/datreant/core/trees.py
@@ -8,7 +8,7 @@ from functools import reduce, total_ordering
 from six import string_types
 
 import scandir
-from pathlib import Path
+from pathlib2 import Path
 from asciitree import LeftAligned
 
 from .util import makedirs
@@ -52,7 +52,7 @@ class Veg(object):
 
     @property
     def path(self):
-        """Filesystem path as a :class:`pathlib.Path`.
+        """Filesystem path as a :class:`pathlib2.Path`.
 
         """
         return self._path


### PR DESCRIPTION
Closes #67.

As of python 3.4, pathlib is now in the standard library. However, to
maintain compatibility with python < 3.4, we include pathlib2 explicitly
as a dependency. We'll drop it eventually when we no longer plan to
support python 3.3 and below.