### PR TITLE
Added overwrite option

### DIFF
--- a/src/datreant/core/rsync.py
+++ b/src/datreant/core/rsync.py
@@ -35,7 +35,8 @@ def rsync(source, dest, compress=True, backup=False, dry=False, checksum=True,
     exclude: str or list
         Paths to be excluded from the copy
     overwrite: bool
-        If True, replace the files in `dest` regardless of timestamp
+        If False, files in `dest` that are newer than files in `source`
+        will not be overwritten
     rsync_path: str
         Path where to find the rsync executable
     """

--- a/src/datreant/core/rsync.py
+++ b/src/datreant/core/rsync.py
@@ -5,7 +5,8 @@ import os
 
 
 def rsync(source, dest, compress=True, backup=False, dry=False, checksum=True,
-          include=None, exclude=None, rsync_path='/usr/bin/rsync'):
+          include=None, exclude=None, overwrite=False,
+          rsync_path='/usr/bin/rsync'):
     """Wrapper function for rsync. There are some minor differences with the
     standard rsync behaviour:
 
@@ -33,10 +34,15 @@ def rsync(source, dest, compress=True, backup=False, dry=False, checksum=True,
         every other path is excluded
     exclude: str or list
         Paths to be excluded from the copy
+    overwrite: bool
+        If True, replace the files in `dest` regardless of timestamp
     rsync_path: str
         Path where to find the rsync executable
     """
     opts = ['-r']  # Recursive
+
+    if not overwrite:
+        opts.append('--ignore-existing')
 
     if compress:
         opts.append('-z')

--- a/src/datreant/core/tests/test_rsync.py
+++ b/src/datreant/core/tests/test_rsync.py
@@ -29,6 +29,25 @@ def _create_tree(name, files=[]):
 
     return tree
 
+def test_overwrite(tmpdir):
+    with tmpdir.as_cwd():
+        sequoia = _create_tree('sequoia', ['hello.txt', 'data/hello.txt',
+                                           'data/world.dat', 'world.dat'])
+        sequoia2 = dtr.Tree("sequoia2").makedirs()
+        
+        # Upload contents
+        sequoia.sync(sequoia2, mode='upload')
+        
+        # Change contents
+        open(sequoia2['hello.txt'].abspath, 'w').write('newcontent')
+        
+        # Upload contents again
+        sequoia.sync(sequoia2, mode='upload')
+        
+        # Verify that the hello.txt is not overwritten
+        assert sequoia2['hello.txt'].read() == 'newcontent'
+        
+
 
 def test_excludes(tmpdir):
     with tmpdir.as_cwd():

--- a/src/datreant/core/trees.py
+++ b/src/datreant/core/trees.py
@@ -471,7 +471,7 @@ class Tree(Veg):
 
     def sync(self, other, mode='upload', compress=True, checksum=True,
              backup=False, dry=False, include=None, exclude=None,
-             rsync_path='/usr/bin/rsync'):
+             overwrite=False, rsync_path='/usr/bin/rsync'):
         """Synchronize directories using rsync.
 
         Parameters
@@ -501,4 +501,5 @@ class Tree(Veg):
         # Here we do some massaging before passing to the rsync function
         return rsync(source, dest, compress=compress, backup=backup,
                      dry=dry, include=include, checksum=checksum,
-                     exclude=exclude, rsync_path=rsync_path)
+                     overwrite=overwrite, exclude=exclude, 
+                     rsync_path=rsync_path)


### PR DESCRIPTION
Typically, rsync will update everything regardless of the
file timestamp. Added default option "--ignore-existing"
that can be turned off with the overwrite flag