### PR TITLE
`AggTags` now has `filter()` method + unit tests

### DIFF
--- a/src/datreant/core/agglimbs.py
+++ b/src/datreant/core/agglimbs.py
@@ -279,17 +279,17 @@ class AggTags(AggLimb):
         return tuple(matches)
 
     def filter(self, tag):
-        """Given tag(s), get a Bundle of Treants whose tags match it.
+        """Filter Treants matching the given tag expression from a Bundle.
 
         Parameters
         ----------
         tag : str or list
-            Tag or tags to get fuzzy matches for.
+            Tag or tags to filter Treants.
 
         Returns
         -------
         Bundle
-            Bundle of Treants with matching tag(s).
+            Bundle of Treants matching the given tag expression.
         """
         matches = self._collection.tags[tag]
         return self._collection[matches]

--- a/src/datreant/core/agglimbs.py
+++ b/src/datreant/core/agglimbs.py
@@ -278,34 +278,20 @@ class AggTags(AggLimb):
 
         return tuple(matches)
 
-    def filter(self, tag, fuzzy=False, threshold=80, scope='all'):
-        """Given tag(s), get a Bundle of Treants whose tags (fuzzily) match it.
+    def filter(self, tag):
+        """Given tag(s), get a Bundle of Treants whose tags match it.
 
         Parameters
         ----------
         tag : str or list
             Tag or tags to get fuzzy matches for.
-        fuzzy : bool
-            Use fuzzy matching [``False``]
-        threshold : int
-            Lowest match score to return. Setting to 0 will return every tag,
-            while setting to 100 will return only exact matches. Only applies
-            when *fuzzy* is ``True``.
-        scope : {'all', 'any'}
-            Tags to use. 'all' will use only tags found within all Treants in
-            collection, while 'any' will use tags found within at least one
-            Treant in collection. Only applies when *fuzzy* is ``True``.
 
         Returns
         -------
         Bundle
             Bundle of Treants with matching tag(s).
         """
-        if fuzzy:
-            tags = self.fuzzy(tag, threshold=threshold, scope=scope)
-        else:
-            tags = tag
-        matches = self._collection.tags[tags]
+        matches = self._collection.tags[tag]
         return self._collection[matches]
 
 

--- a/src/datreant/core/agglimbs.py
+++ b/src/datreant/core/agglimbs.py
@@ -243,7 +243,7 @@ class AggTags(AggLimb):
 
         Parameters
         ----------
-        tags : str or list
+        tag : str or list
             Tag or tags to get fuzzy matches for.
         threshold : int
             Lowest match score to return. Setting to 0 will return every tag,
@@ -277,6 +277,36 @@ class AggTags(AggLimb):
                         if i[1] > threshold]
 
         return tuple(matches)
+
+    def filter(self, tag, fuzzy=False, threshold=80, scope='all'):
+        """Given tag(s), get a Bundle of Treants whose tags (fuzzily) match it.
+
+        Parameters
+        ----------
+        tag : str or list
+            Tag or tags to get fuzzy matches for.
+        fuzzy : bool
+            Use fuzzy matching [``False``]
+        threshold : int
+            Lowest match score to return. Setting to 0 will return every tag,
+            while setting to 100 will return only exact matches. Only applies
+            when *fuzzy* is ``True``.
+        scope : {'all', 'any'}
+            Tags to use. 'all' will use only tags found within all Treants in
+            collection, while 'any' will use tags found within at least one
+            Treant in collection. Only applies when *fuzzy* is ``True``.
+
+        Returns
+        -------
+        Bundle
+            Bundle of Treants with matching tag(s).
+        """
+        if fuzzy:
+            tags = self.fuzzy(tag, threshold=threshold, scope=scope)
+        else:
+            tags = tag
+        matches = self._collection.tags[tags]
+        return self._collection[matches]
 
 
 class AggCategories(AggLimb):

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -412,7 +412,7 @@ class TestBundle:
                 any_ny_strict = tags.fuzzy('new york', scope='any')
                 assert any_ny_strict == ('new york',)
                 any_ny_tol = tags.fuzzy('new york', threshold=50, scope='any')
-                assert any_ny_tol == ('new york', 'new jersey')
+                assert set(any_ny_tol) == {'new york', 'new jersey'}
 
                 # check fuzzy matching for multiple tags (scope='all')
                 new_ever = ['new', 'evergreen']
@@ -426,10 +426,10 @@ class TestBundle:
                 any_mul_stric = tags.fuzzy(new_tree, threshold=90, scope='any')
                 assert any_mul_stric == ('tree',)
                 any_mul_tol = tags.fuzzy(new_tree, threshold=80, scope='any')
-                assert any_mul_tol == ('new york', 'new jersey', 'tree')
+                assert set(any_mul_tol) == {'new york', 'new jersey', 'tree'}
                 nj_decid = ['new jersey', 'decid']
                 any_mul_njdec = tags.fuzzy(nj_decid, threshold=80, scope='any')
-                assert any_mul_njdec == ('new jersey', 'deciduous')
+                assert set(any_mul_njdec) == {'new jersey', 'deciduous'}
 
         def test_tags_filter(self, collection, testtreant, testgroup, tmpdir):
             with tmpdir.as_cwd():

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -376,7 +376,40 @@ class TestBundle:
             pass
 
         def test_tags_fuzzy(self, collection, testtreant, testgroup, tmpdir):
-            pass
+            with tmpdir.as_cwd():
+
+                t1 = dtr.Treant('maple')
+                t2 = dtr.Treant('pine')
+                t1.tags.add({'tree', 'new jersey', 'deciduous'})
+                t2.tags.add({'tree', 'new york', 'evergreen'})
+                collection.add(t1, t2)
+                tags = collection.tags
+
+                assert len(tags.any) == 5
+
+                assert tags.fuzzy('tree')[0] == 'tree'
+                assert tags.fuzzy('deciduous', scope='any')[0] == 'deciduous'
+                assert tags.fuzzy('evergreen')[0] == ()
+                assert tags.fuzzy('tree', threshold=99, scope='all')[0] == 'tree'
+                assert tags.fuzzy('tree', threshold=1, scope='all')[0] == 'tree'
+                assert tags.fuzzy('new york', threshold=80)[0] == 'new york'
+                assert tags.fuzzy('new york', threshold=50) == ('new york', 'new jersey')
+
+        def test_tags_filter(self, collection, testtreant, testgroup, tmpdir):
+            with tmpdir.as_cwd():
+
+                t1 = dtr.Treant('maple')
+                t2 = dtr.Treant('pine')
+                t1.tags.add({'tree', 'new jersey', 'deciduous'})
+                t2.tags.add({'tree', 'new york', 'evergreen'})
+                collection.add(t1, t2)
+                tags = collection.tags
+
+                assert len(tags.any) == 5
+
+                assert tags.filter('tree') == collection
+                assert tags.filter('new york') == t1
+                assert tags.filter('adult') == t2
 
     class TestAggCategories:
         """Test behavior of manipulating categories collectively.

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -423,10 +423,10 @@ class TestBundle:
 
                 # complex logic tests
 
-                # give me if its evergreen or in NY AND also not deciduous
+                # give those that are evergreen or in NY AND also not deciduous
                 selection = [('evergreen', 'new york'), {'deciduous'}]
                 assert tags[selection] == [False, True]
-                # give me if its evergreen or in NY AND also not a tree
+                # give those that are evergreen or in NY AND also not a tree
                 selection = [('evergreen', 'new york'), {'tree'}]
                 assert tags[selection] == [False, False]
                 # give a tree that's in NJ OR anything that's not evergreen
@@ -503,34 +503,53 @@ class TestBundle:
                 collection.add(maple, pine)
                 tags = collection.tags
 
+                maple_bund = dtr.Bundle(maple)
+                pine_bund = dtr.Bundle(pine)
+
                 assert len(tags.any) == 5
 
                 # filter using single tags
                 assert tags.filter('tree') == collection
                 assert tags.filter({'tree'}) == dtr.Bundle()
-                assert tags.filter('deciduous')[0] == maple
-                assert tags.filter('evergreen')[0] == pine
-                assert tags.filter('new jersey')[0] == maple
-                assert tags.filter('new york')[0] == pine
+                assert tags.filter('deciduous') == maple_bund
+                assert tags.filter('evergreen') == pine_bund
+                assert tags.filter('new jersey') == maple_bund
+                assert tags.filter('new york') == pine_bund
 
                 # filter Treants that DON'T have a given tag
-                assert tags.filter({'new york'})[0] == maple
-                assert tags.filter({'deciduous'})[0] == pine
+                assert tags.filter({'new york'}) == maple_bund
+                assert tags.filter({'deciduous'}) == pine_bund
 
                 # filter Treants containing all of the tags
-                assert tags.filter(['deciduous', 'tree'])[0] == maple
-                assert tags.filter(['evergreen', 'tree'])[0] == pine
+                assert tags.filter(['deciduous', 'tree']) == maple_bund
+                assert tags.filter(['evergreen', 'tree']) == pine_bund
                 assert tags.filter(['deciduous', 'new york']) == dtr.Bundle()
 
                 # filter Treants containing any of the tags tags
                 assert tags.filter(('evergreen', 'tree')) == collection
                 assert tags.filter(('deciduous', 'new york')) == collection
-                assert tags.filter(('evergreen', 'new york'))[0] == pine
+                assert tags.filter(('evergreen', 'new york')) == pine_bund
 
                 # filter Treants that exclude any of the provided tags
                 assert tags.filter({'deciduous', 'new york'}) == collection
-                assert tags.filter({'deciduous', 'new jersey'})[0] == pine
-                assert tags.filter({'evergreen', 'tree'})[0] == maple
+                assert tags.filter({'deciduous', 'new jersey'}) == pine_bund
+                assert tags.filter({'evergreen', 'tree'}) == maple_bund
+
+                # complex logic tests
+
+                # give those that are evergreen or in NY AND also not deciduous
+                selection = [('evergreen', 'new york'), {'deciduous'}]
+                assert tags.filter(selection) == pine_bund
+                # give those that are evergreen or in NY AND also not a tree
+                selection = [('evergreen', 'new york'), {'tree'}]
+                assert tags.filter(selection) == dtr.Bundle()
+                # give a tree that's in NJ OR anything that's not evergreen
+                selection = (['tree', 'new jersey'], {'evergreen'})
+                assert tags.filter(selection) == maple_bund
+                # cannot be a tree in NJ, AND must also be deciduous
+                # I.e., give all deciduous things that aren't trees in NJ
+                selection = [{'tree', 'new jersey'}, 'deciduous']
+                assert tags.filter(selection) == dtr.Bundle()
 
     class TestAggCategories:
         """Test behavior of manipulating categories collectively.

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -446,11 +446,14 @@ class TestBundle:
                 # filter using single tags
                 assert tags.filter('tree') == collection
                 assert tags.filter({'tree'}) == dtr.Bundle()
-                assert tags.filter('new jersey')[0] == maple
-                assert tags.filter('new york')[0] == pine
-                assert tags.filter({'new york'})[0] == maple
                 assert tags.filter('deciduous')[0] == maple
                 assert tags.filter('evergreen')[0] == pine
+                assert tags.filter('new jersey')[0] == maple
+                assert tags.filter('new york')[0] == pine
+
+                # filter Treants that DON'T have a given tag
+                assert tags.filter({'new york'})[0] == maple
+                assert tags.filter({'deciduous'})[0] == pine
 
                 # filter Treants containing all of the tags
                 assert tags.filter(['deciduous', 'tree'])[0] == maple
@@ -462,7 +465,7 @@ class TestBundle:
                 assert tags.filter(('deciduous', 'new york')) == collection
                 assert tags.filter(('evergreen', 'new york'))[0] == pine
 
-                # filter Treants not containing any of the tags (XOR)
+                # filter Treants that exclude any of the provided tags
                 assert tags.filter({'deciduous', 'new york'}) == collection
                 assert tags.filter({'deciduous', 'new jersey'})[0] == pine
                 assert tags.filter({'evergreen', 'tree'})[0] == maple

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -387,33 +387,49 @@ class TestBundle:
 
                 assert len(tags.any) == 5
 
-                assert tags.fuzzy('tree', threshold=80, scope='all') == tags.fuzzy('tree')
-                assert tags.fuzzy('tree')[0] == 'tree'
-                assert tags.fuzzy('deciduous', scope='any')[0] == 'deciduous'
-                assert tags.fuzzy('evergreen')[0] == ()
+                all_tree1 = tags.fuzzy('tree', threshold=80, scope='all')
+                all_tree2 = tags.fuzzy('tree')
+                assert all_tree1 == all_tree2
+                assert all_tree2 == ('tree',)
+
+                any_deciduous = tags.fuzzy('deciduous', scope='any')
+                assert any_deciduous == ('deciduous',)
+                all_evergreen = tags.fuzzy('evergreen')
+                assert all_evergreen == ()
 
                 # check that fuzzy matching is independent of threshold when
                 # exact tag is present in all members
-                assert tags.fuzzy('tree', threshold=99, scope='all')[0] == 'tree'
-                assert tags.fuzzy('tree', threshold=0, scope='all')[0] == 'tree'
+                all_tree_strict = tags.fuzzy('tree', threshold=99)
+                assert all_tree_strict == ('tree',)
+                all_tree_tolerant = tags.fuzzy('tree', threshold=0)
+                assert all_tree_tolerant == ('tree',)
 
                 # check that fuzzy matching will give differing tags when
                 # members have similar tag names ('new') and the threshold is
                 # varied
-                assert tags.fuzzy('new york') == ('new york',)
-                assert tags.fuzzy('new york', threshold=50, scope='any') == ('new york', 'new jersey')
+                all_ny = tags.fuzzy('new york')
+                assert all_ny == ()
+                any_ny_strict = tags.fuzzy('new york', scope='any')
+                assert any_ny_strict == ('new york',)
+                any_ny_tol = tags.fuzzy('new york', threshold=50, scope='any')
+                assert any_ny_tol == ('new york', 'new jersey')
 
                 # check fuzzy matching for multiple tags (scope='all')
-                assert tags.fuzzy(['new','evergreen'], threshold=80) == ()
-                assert tags.fuzzy(['new','evergreen'], threshold=30) == ('tree')
+                new_ever = ['new', 'evergreen']
+                all_mul_strict = tags.fuzzy(new_ever, threshold=80)
+                assert all_mul_strict == ()
+                all_mul_tol = tags.fuzzy(new_ever, threshold=30)
+                assert all_mul_tol == ('tree',)
 
                 # check fuzzy matching for multiple tags (scope='any')
-                assert tags.fuzzy(['new','tree'], threshold=90, scope='any')
-                            == ('tree')
-                assert tags.fuzzy(['new','tree'], threshold=80, scope='any')
-                            == ('new york', 'new jersey', 'tree')
-                assert tags.fuzzy(['new jersey', 'decid'], threshold=80, scope='any')
-                            == ('new jersey', 'deciduous')
+                new_tree = ['new', 'tree']
+                any_mul_stric = tags.fuzzy(new_tree, threshold=90, scope='any')
+                assert any_mul_stric == ('tree',)
+                any_mul_tol = tags.fuzzy(new_tree, threshold=80, scope='any')
+                assert any_mul_tol == ('new york', 'new jersey', 'tree')
+                nj_decid = ['new jersey', 'decid']
+                any_mul_njdec = tags.fuzzy(nj_decid, threshold=80, scope='any')
+                assert any_mul_njdec == ('new jersey', 'deciduous')
 
         def test_tags_filter(self, collection, testtreant, testgroup, tmpdir):
             with tmpdir.as_cwd():
@@ -428,11 +444,10 @@ class TestBundle:
                 assert len(tags.any) == 5
 
                 assert tags.filter('tree') == collection
-                assert tags.filter('deciduous')[0] == pine
-                assert tags.filter('evergreen')[0] == maple
+                assert tags.filter('deciduous')[0] == maple
+                assert tags.filter('evergreen')[0] == pine
                 assert tags.filter('new jersey')[0] == maple
                 assert tags.filter('new york')[0] == pine
-
 
     class TestAggCategories:
         """Test behavior of manipulating categories collectively.

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -419,6 +419,23 @@ class TestBundle:
                 assert tags[{'tree', 'deciduous'}] == [False, True]
                 assert tags[{'tree', 'new york'}] == [True, False]
                 assert tags[{'tree', 'new york', 'deciduous'}] == [True, True]
+                assert tags[{'tree', 'new york', 'evergreen'}] == [True, False]
+
+                # complex logic tests
+
+                # give me if its evergreen or in NY AND also not deciduous
+                selection = [('evergreen', 'new york'), {'deciduous'}]
+                assert tags[selection] == [False, True]
+                # give me if its evergreen or in NY AND also not a tree
+                selection = [('evergreen', 'new york'), {'tree'}]
+                assert tags[selection] == [False, False]
+                # give a tree that's in NJ OR anything that's not evergreen
+                selection = (['tree', 'new jersey'], {'evergreen'})
+                assert tags[selection] == [True, False]
+                # cannot be a tree in NJ, AND must also be deciduous
+                # I.e., give all deciduous things that aren't trees in NJ
+                selection = [{'tree', 'new jersey'}, 'deciduous']
+                assert tags[selection] == [False, False]
 
         def test_tags_fuzzy(self, collection, testtreant, testgroup, tmpdir):
             with tmpdir.as_cwd():

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -412,6 +412,8 @@ class TestBundle:
                             == ('tree')
                 assert tags.fuzzy(['new','tree'], threshold=80, scope='any')
                             == ('new york', 'new jersey', 'tree')
+                assert tags.fuzzy(['new jersey', 'decid'], threshold=80, scope='any')
+                            == ('new jersey', 'deciduous')
 
         def test_tags_filter(self, collection, testtreant, testgroup, tmpdir):
             with tmpdir.as_cwd():
@@ -430,10 +432,6 @@ class TestBundle:
                 assert tags.filter('evergreen')[0] == maple
                 assert tags.filter('new jersey')[0] == maple
                 assert tags.filter('new york')[0] == pine
-                assert tags.filter('new york', fuzzy=True,
-                                   threshold=80, scope='any') == dtr.Bundle('pine')
-                assert tags.filter('new york', fuzzy=True,
-                                   threshold=50, scope='any') == collection
 
 
     class TestAggCategories:

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -373,7 +373,52 @@ class TestBundle:
             pass
 
         def test_tags_getitem(self, collection, testtreant, testgroup, tmpdir):
-            pass
+            with tmpdir.as_cwd():
+
+                t1 = dtr.Treant('maple')
+                t2 = dtr.Treant('pine')
+                t1.tags.add({'tree', 'new jersey', 'deciduous'})
+                t2.tags.add({'tree', 'new york', 'evergreen'})
+                collection.add(t1, t2)
+                tags = collection.tags
+
+                assert len(tags.any) == 5
+
+                # test single tags
+                assert tags['tree'] == [True, True]
+                assert tags['deciduous'] == [True, False]
+                assert tags['evergreen'] == [False, True]
+                assert tags['new jersey'] == [True, False]
+                assert tags['new york'] == [False, True]
+
+                assert tags[{'tree'}] == [False, False]
+                assert tags[{'deciduous'}] == [False, True]
+                assert tags[{'evergreen'}] == [True, False]
+                assert tags[{'new jersey'}] == [False, True]
+                assert tags[{'new york'}] == [True, False]
+
+                # test for Treants with ALL the given tags
+                assert tags[['tree', 'deciduous']] == [True, False]
+                assert tags[['tree', 'evergreen']] == [False, True]
+                assert tags[['new jersey', 'evergreen']] == [False, False]
+                assert tags[['new jersey', 'deciduous']] == [True, False]
+
+                # test for Treants with ANY the given tags
+                assert tags[('tree', 'deciduous')] == [True, True]
+                assert tags[('tree', 'evergreen')] == [True, True]
+                assert tags[('new jersey', 'evergreen')] == [True, True]
+                assert tags[('new jersey', 'deciduous')] == [True, False]
+
+                assert tags['tree', 'deciduous'] == [True, True]
+                assert tags['tree', 'evergreen'] == [True, True]
+                assert tags['new jersey', 'evergreen'] == [True, True]
+                assert tags['new jersey', 'deciduous'] == [True, False]
+
+                # test for Treants not having ANY of the given tags
+                assert tags[{'tree'}] == [False, False]
+                assert tags[{'tree', 'deciduous'}] == [False, True]
+                assert tags[{'tree', 'new york'}] == [True, False]
+                assert tags[{'tree', 'new york', 'deciduous'}] == [True, True]
 
         def test_tags_fuzzy(self, collection, testtreant, testgroup, tmpdir):
             with tmpdir.as_cwd():

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -373,69 +373,7 @@ class TestBundle:
             pass
 
         def test_tags_getitem(self, collection, testtreant, testgroup, tmpdir):
-            with tmpdir.as_cwd():
-
-                t1 = dtr.Treant('maple')
-                t2 = dtr.Treant('pine')
-                t1.tags.add({'tree', 'new jersey', 'deciduous'})
-                t2.tags.add({'tree', 'new york', 'evergreen'})
-                collection.add(t1, t2)
-                tags = collection.tags
-
-                assert len(tags.any) == 5
-
-                # test single tags
-                assert tags['tree'] == [True, True]
-                assert tags['deciduous'] == [True, False]
-                assert tags['evergreen'] == [False, True]
-                assert tags['new jersey'] == [True, False]
-                assert tags['new york'] == [False, True]
-
-                assert tags[{'tree'}] == [False, False]
-                assert tags[{'deciduous'}] == [False, True]
-                assert tags[{'evergreen'}] == [True, False]
-                assert tags[{'new jersey'}] == [False, True]
-                assert tags[{'new york'}] == [True, False]
-
-                # test for Treants with ALL the given tags
-                assert tags[['tree', 'deciduous']] == [True, False]
-                assert tags[['tree', 'evergreen']] == [False, True]
-                assert tags[['new jersey', 'evergreen']] == [False, False]
-                assert tags[['new jersey', 'deciduous']] == [True, False]
-
-                # test for Treants with ANY the given tags
-                assert tags[('tree', 'deciduous')] == [True, True]
-                assert tags[('tree', 'evergreen')] == [True, True]
-                assert tags[('new jersey', 'evergreen')] == [True, True]
-                assert tags[('new jersey', 'deciduous')] == [True, False]
-
-                assert tags['tree', 'deciduous'] == [True, True]
-                assert tags['tree', 'evergreen'] == [True, True]
-                assert tags['new jersey', 'evergreen'] == [True, True]
-                assert tags['new jersey', 'deciduous'] == [True, False]
-
-                # test for Treants not having ANY of the given tags
-                assert tags[{'tree'}] == [False, False]
-                assert tags[{'tree', 'deciduous'}] == [False, True]
-                assert tags[{'tree', 'new york'}] == [True, False]
-                assert tags[{'tree', 'new york', 'deciduous'}] == [True, True]
-                assert tags[{'tree', 'new york', 'evergreen'}] == [True, False]
-
-                # complex logic tests
-
-                # give those that are evergreen or in NY AND also not deciduous
-                selection = [('evergreen', 'new york'), {'deciduous'}]
-                assert tags[selection] == [False, True]
-                # give those that are evergreen or in NY AND also not a tree
-                selection = [('evergreen', 'new york'), {'tree'}]
-                assert tags[selection] == [False, False]
-                # give a tree that's in NJ OR anything that's not evergreen
-                selection = (['tree', 'new jersey'], {'evergreen'})
-                assert tags[selection] == [True, False]
-                # cannot be a tree in NJ, AND must also be deciduous
-                # I.e., give all deciduous things that aren't trees in NJ
-                selection = [{'tree', 'new jersey'}, 'deciduous']
-                assert tags[selection] == [False, False]
+            pass
 
         def test_tags_fuzzy(self, collection, testtreant, testgroup, tmpdir):
             pass

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -398,18 +398,25 @@ class TestBundle:
         def test_tags_filter(self, collection, testtreant, testgroup, tmpdir):
             with tmpdir.as_cwd():
 
-                t1 = dtr.Treant('maple')
-                t2 = dtr.Treant('pine')
-                t1.tags.add({'tree', 'new jersey', 'deciduous'})
-                t2.tags.add({'tree', 'new york', 'evergreen'})
-                collection.add(t1, t2)
+                maple = dtr.Treant('maple')
+                pine = dtr.Treant('pine')
+                maple.tags.add({'tree', 'new jersey', 'deciduous'})
+                pine.tags.add({'tree', 'new york', 'evergreen'})
+                collection.add(maple, pine)
                 tags = collection.tags
 
                 assert len(tags.any) == 5
 
                 assert tags.filter('tree') == collection
-                assert tags.filter('new york') == t1
-                assert tags.filter('adult') == t2
+                assert tags.filter('deciduous')[0] == pine
+                assert tags.filter('evergreen')[0] == maple
+                assert tags.filter('new jersey')[0] == maple
+                assert tags.filter('new york')[0] == pine
+                assert tags.filter('new york', fuzzy=True,
+                                   threshold=80, scope='any') == dtr.Bundle('pine')
+                assert tags.filter('new york', fuzzy=True,
+                                   threshold=50, scope='any') == collection
+
 
     class TestAggCategories:
         """Test behavior of manipulating categories collectively.

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -443,11 +443,29 @@ class TestBundle:
 
                 assert len(tags.any) == 5
 
+                # filter using single tags
                 assert tags.filter('tree') == collection
-                assert tags.filter('deciduous')[0] == maple
-                assert tags.filter('evergreen')[0] == pine
+                assert tags.filter({'tree'}) == dtr.Bundle()
                 assert tags.filter('new jersey')[0] == maple
                 assert tags.filter('new york')[0] == pine
+                assert tags.filter({'new york'})[0] == maple
+                assert tags.filter('deciduous')[0] == maple
+                assert tags.filter('evergreen')[0] == pine
+
+                # filter Treants containing all of the tags
+                assert tags.filter(['deciduous', 'tree'])[0] == maple
+                assert tags.filter(['evergreen', 'tree'])[0] == pine
+                assert tags.filter(['deciduous', 'new york']) == dtr.Bundle()
+
+                # filter Treants containing any of the tags tags
+                assert tags.filter(('evergreen', 'tree')) == collection
+                assert tags.filter(('deciduous', 'new york')) == collection
+                assert tags.filter(('evergreen', 'new york'))[0] == pine
+
+                # filter Treants not containing any of the tags (XOR)
+                assert tags.filter({'deciduous', 'new york'}) == collection
+                assert tags.filter({'deciduous', 'new jersey'})[0] == pine
+                assert tags.filter({'evergreen', 'tree'})[0] == maple
 
     class TestAggCategories:
         """Test behavior of manipulating categories collectively.

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -387,13 +387,31 @@ class TestBundle:
 
                 assert len(tags.any) == 5
 
+                assert tags.fuzzy('tree', threshold=80, scope='all') == tags.fuzzy('tree')
                 assert tags.fuzzy('tree')[0] == 'tree'
                 assert tags.fuzzy('deciduous', scope='any')[0] == 'deciduous'
                 assert tags.fuzzy('evergreen')[0] == ()
+
+                # check that fuzzy matching is independent of threshold when
+                # exact tag is present in all members
                 assert tags.fuzzy('tree', threshold=99, scope='all')[0] == 'tree'
-                assert tags.fuzzy('tree', threshold=1, scope='all')[0] == 'tree'
-                assert tags.fuzzy('new york', threshold=80)[0] == 'new york'
-                assert tags.fuzzy('new york', threshold=50) == ('new york', 'new jersey')
+                assert tags.fuzzy('tree', threshold=0, scope='all')[0] == 'tree'
+
+                # check that fuzzy matching will give differing tags when
+                # members have similar tag names ('new') and the threshold is
+                # varied
+                assert tags.fuzzy('new york') == ('new york',)
+                assert tags.fuzzy('new york', threshold=50, scope='any') == ('new york', 'new jersey')
+
+                # check fuzzy matching for multiple tags (scope='all')
+                assert tags.fuzzy(['new','evergreen'], threshold=80) == ()
+                assert tags.fuzzy(['new','evergreen'], threshold=30) == ('tree')
+
+                # check fuzzy matching for multiple tags (scope='any')
+                assert tags.fuzzy(['new','tree'], threshold=90, scope='any')
+                            == ('tree')
+                assert tags.fuzzy(['new','tree'], threshold=80, scope='any')
+                            == ('new york', 'new jersey', 'tree')
 
         def test_tags_filter(self, collection, testtreant, testgroup, tmpdir):
             with tmpdir.as_cwd():

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -438,60 +438,7 @@ class TestBundle:
                 assert tags[selection] == [False, False]
 
         def test_tags_fuzzy(self, collection, testtreant, testgroup, tmpdir):
-            with tmpdir.as_cwd():
-
-                t1 = dtr.Treant('maple')
-                t2 = dtr.Treant('pine')
-                t1.tags.add({'tree', 'new jersey', 'deciduous'})
-                t2.tags.add({'tree', 'new york', 'evergreen'})
-                collection.add(t1, t2)
-                tags = collection.tags
-
-                assert len(tags.any) == 5
-
-                all_tree1 = tags.fuzzy('tree', threshold=80, scope='all')
-                all_tree2 = tags.fuzzy('tree')
-                assert all_tree1 == all_tree2
-                assert all_tree2 == ('tree',)
-
-                any_deciduous = tags.fuzzy('deciduous', scope='any')
-                assert any_deciduous == ('deciduous',)
-                all_evergreen = tags.fuzzy('evergreen')
-                assert all_evergreen == ()
-
-                # check that fuzzy matching is independent of threshold when
-                # exact tag is present in all members
-                all_tree_strict = tags.fuzzy('tree', threshold=99)
-                assert all_tree_strict == ('tree',)
-                all_tree_tolerant = tags.fuzzy('tree', threshold=0)
-                assert all_tree_tolerant == ('tree',)
-
-                # check that fuzzy matching will give differing tags when
-                # members have similar tag names ('new') and the threshold is
-                # varied
-                all_ny = tags.fuzzy('new york')
-                assert all_ny == ()
-                any_ny_strict = tags.fuzzy('new york', scope='any')
-                assert any_ny_strict == ('new york',)
-                any_ny_tol = tags.fuzzy('new york', threshold=50, scope='any')
-                assert set(any_ny_tol) == {'new york', 'new jersey'}
-
-                # check fuzzy matching for multiple tags (scope='all')
-                new_ever = ['new', 'evergreen']
-                all_mul_strict = tags.fuzzy(new_ever, threshold=80)
-                assert all_mul_strict == ()
-                all_mul_tol = tags.fuzzy(new_ever, threshold=30)
-                assert all_mul_tol == ('tree',)
-
-                # check fuzzy matching for multiple tags (scope='any')
-                new_tree = ['new', 'tree']
-                any_mul_stric = tags.fuzzy(new_tree, threshold=90, scope='any')
-                assert any_mul_stric == ('tree',)
-                any_mul_tol = tags.fuzzy(new_tree, threshold=80, scope='any')
-                assert set(any_mul_tol) == {'new york', 'new jersey', 'tree'}
-                nj_decid = ['new jersey', 'decid']
-                any_mul_njdec = tags.fuzzy(nj_decid, threshold=80, scope='any')
-                assert set(any_mul_njdec) == {'new jersey', 'deciduous'}
+            pass
 
         def test_tags_filter(self, collection, testtreant, testgroup, tmpdir):
             with tmpdir.as_cwd():


### PR DESCRIPTION
Added `filter()` method to `AggTags`. Opted to leave out fuzzy matching for the time being due to ambiguities in possible implementations. Unit tests were added for both `AggTags.fuzzy()` (originally intended to include fuzzy matching in `filter()` and `AggTags.filter()`).