### PR TITLE
Fixed behavior of groupby to preserve order of multiple keys (Issue #72)

### DIFF
--- a/src/datreant/core/agglimbs.py
+++ b/src/datreant/core/agglimbs.py
@@ -572,7 +572,7 @@ class AggCategories(AggLimb):
         corresponding Bundles are groupings of members in the collection having
         the same category values (for the category specied by `keys`).
 
-        If `keys` is a list or set of keys, returns a dict of Bundles whose
+        If `keys` is a list of keys, returns a dict of Bundles whose
         (new) keys are tuples of category values. The corresponding Bundles
         contain the members in the collection that have the same set of
         category values (for the categories specified by `keys`); members in
@@ -581,7 +581,7 @@ class AggCategories(AggLimb):
 
         Parameters
         ----------
-        keys : str, list, set
+        keys : str, list
             Valid key(s) of categories in this collection.
 
         Returns
@@ -603,9 +603,8 @@ class AggCategories(AggLimb):
                    k in m.categories and m.categories[k] in groupkeys)
             for m, catval in gen:
                 groups[catval].add(m)
-
-        elif isinstance(keys, (list, set)):
-            keys = sorted(keys)
+        # Note: redundant code in if/elif block can be consolidated in future
+        elif isinstance(keys, list):
             catvals = list(zip(*members.categories[keys]))
             groupkeys = [v for v in catvals if None not in v]
             groups = {k: Bundle() for k in groupkeys}

--- a/src/datreant/core/agglimbs.py
+++ b/src/datreant/core/agglimbs.py
@@ -616,6 +616,6 @@ class AggCategories(AggLimb):
                 groups[catvals[i]].add(m)
 
         else:
-            raise TypeError("Keys must be a string or a list or set of"
+            raise TypeError("Keys must be a string or a list of"
                             " strings")
         return groups

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -788,17 +788,10 @@ class TestBundle:
                 assert {t3} == set(age_bark[('old', 'mossy')])
                 assert {t4} == set(age_bark[('young', 'mossy')])
 
-                age_bark = collection.categories.groupby({'age', 'bark'})
-                assert len(age_bark) == 4
-                assert {t1} == set(age_bark[('young', 'smooth')])
-                assert {t2} == set(age_bark[('adult', 'fibrous')])
-                assert {t3} == set(age_bark[('old', 'mossy')])
-                assert {t4} == set(age_bark[('young', 'mossy')])
-
                 type_health = collection.categories.groupby(['type', 'health'])
                 assert len(type_health) == 2
-                assert {t3} == set(type_health[('poor', 'deciduous')])
-                assert {t4} == set(type_health[('good', 'deciduous')])
+                assert {t3} == set(type_health[('deciduous', 'poor')])
+                assert {t4} == set(type_health[('deciduous', 'good')])
                 for bundle in type_health.values():
                     assert {t1, t2}.isdisjoint(set(bundle))
 
@@ -826,25 +819,17 @@ class TestBundle:
                 keys = ['age', 'bark', 'type', 'nickname']
                 abtn = collection.categories.groupby(keys)
                 assert len(abtn) == 1
-                assert {t2} == set(abtn[('adult', 'fibrous', 'redwood',
-                                         'evergreen')])
+                assert {t2} == set(abtn[('adult', 'fibrous', 'evergreen',
+                                         'redwood')])
                 for bundle in abtn.values():
                     assert {t1, t3, t4}.isdisjoint(set(bundle))
 
                 keys = ['bark', 'nickname', 'type', 'age']
                 abtn2 = collection.categories.groupby(keys)
                 assert len(abtn2) == 1
-                assert {t2} == set(abtn2[('adult', 'fibrous', 'redwood',
-                                          'evergreen')])
+                assert {t2} == set(abtn2[('fibrous', 'redwood', 'evergreen',
+                                          'adult')])
                 for bundle in abtn2.values():
-                    assert {t1, t3, t4}.isdisjoint(set(bundle))
-
-                keys = {'age', 'bark', 'type', 'nickname'}
-                abtn_set = collection.categories.groupby(keys)
-                assert len(abtn_set) == 1
-                assert {t2} == set(abtn_set[('adult', 'fibrous', 'redwood',
-                                             'evergreen')])
-                for bundle in abtn_set.values():
                     assert {t1, t3, t4}.isdisjoint(set(bundle))
 
                 keys = ['health', 'nickname']

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -837,3 +837,7 @@ class TestBundle:
                 assert len(health_nick) == 0
                 for bundle in health_nick.values():
                     assert {t1, t2, t3, t4}.isdisjoint(set(bundle))
+
+                # Test key TypeError in groupby
+                with pytest.raises(TypeError) as e:
+                    collection.categories.groupby({'health', 'nickname'})


### PR DESCRIPTION
`groupby()` originally could take a list *or* a set of category keys as input. This implementation did not deal preserve the order of the keys (when provided as a list) in the output. The fix was to no longer accept sets of keys and just take lists to deal with multiple keys. Removing the sorting now preserves the order of the keys in the output (dictionary).

The AggCategories tests were updated to reflect the preservation of key input order.