### PR TITLE
parametrize tests

### DIFF
--- a/src/datreant/core/tests/test_treants.py
+++ b/src/datreant/core/tests/test_treants.py
@@ -380,25 +380,25 @@ class TestTreant(TestTree):
             with pytest.raises(TypeError):
                 treant.categories.add(['mark', 'matt'])
 
-        def test_add_wrong_keys(self, treant):
+        @pytest.mark.parametrize('key, val', [[2, 'twenty'],
+                                              [['blarg'], "nothin'"],
+                                              [None, "literally nothin'"],
+                                              [True, 'tautologically']])
+        def test_add_wrong_keys(self, treant, key, val):
+            # always test both addition methods
             with pytest.raises(TypeError):
-                treant.categories[2] = 'twenty'
+                treant.categories[key] = val
+            with pytest.raises(TypeError):
+                treant.categories.add(key, val)
 
+        @pytest.mark.parametrize('key, val', [['bark', ['shaggy']],
+                                              ['snark', {'yes'}]])
+        def test_add_wrong_values(self, treant, key, val):
+            # always test both addition methods
             with pytest.raises(TypeError):
-                treant.categories[['blarg']] = "nothin'"
-
+                treant.categories.add(key, val)
             with pytest.raises(TypeError):
-                treant.categories[None] = "literally nothin'"
-
-            with pytest.raises(TypeError):
-                treant.categories[True] = "tautologically"
-
-        def test_add_wrong_values(self, treant):
-            with pytest.raises(TypeError):
-                treant.categories['bark'] = ['shaggy']
-
-            with pytest.raises(TypeError):
-                treant.categories['snark'] = {'yes'}
+                treant.categories[key] = val
 
         def test_None_no_change(self, treant):
             """Setting a category to ``None`` should not change the value.


### PR DESCRIPTION
Makes it a bit more readable and increases the checks by always confirming that I can add new values with `add` and  `__getitem__`.