### PR TITLE
Fix category adding fixes 102

### DIFF
--- a/src/datreant/core/limbs.py
+++ b/src/datreant/core/limbs.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 
 from fuzzywuzzy import process
 
-from . import filesystem
 from .collections import Bundle
 from . import _TREELIMBS, _LIMBS
 

--- a/src/datreant/core/limbs.py
+++ b/src/datreant/core/limbs.py
@@ -495,7 +495,7 @@ class Categories(Limb):
 
         """
         outcats = dict()
-        if isinstance(categorydict, dict):
+        if isinstance(categorydict, (dict, Categories)):
             outcats.update(categorydict)
         elif categorydict is None:
             pass

--- a/src/datreant/core/tests/test_treants.py
+++ b/src/datreant/core/tests/test_treants.py
@@ -454,6 +454,10 @@ class TestTreant(TestTree):
             treant.categories = s.categories
             assert treant.categories == s.categories
 
+        def test_from_treant(self, treant, tmpdir):
+            with tmpdir.as_cwd():
+                dtr.Treant('sprout', categories=treant.categories)
+
 
 class TestGroup(TestTreant):
     """Test Group-specific features.


### PR DESCRIPTION
fixes #102

This should allow to add `Categories` to a treant. @dotsdl where should a test for this be done? I didn't find a `test_limbs.py` file.