### PR TITLE
Remove deprecated 'py.test' package from documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -69,4 +69,4 @@ This will run all the tests for that subpackage (often inside
 Note that to run the tests you will need to install ``py.test`` and the
 coverage and PEP8 plugins into your virtualenv::
 
-    pip install py.test pytest pytest-cov pytest-pep8
+    pip install pytest pytest-cov pytest-pep8


### PR DESCRIPTION
Trying to run ``pip install py.test`` will throw an error, as the old package ``py.test`` is not supposed to be used anymore. Also mentioned on the [PyPI page](https://pypi.python.org/pypi/py.test).

```
Collecting py.test
  Downloading py.test-0.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-cn8QrV/py.test/setup.py", line 6, in <module>
        raise ValueError("please use 'pytest' pypi package instead of 'py.test'")
    ValueError: please use 'pytest' pypi package instead of 'py.test'
```

The command ``py.test`` will still work when only installing ``pytest``.