### PR TITLE
Tags non string warning fixes #123

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,7 @@ Enhancements
     
 
 Fixes
-    
+    * Raise exception if wrong tag type is added (Issue #123)
 
 Changes
 

--- a/src/datreant/core/limbs.py
+++ b/src/datreant/core/limbs.py
@@ -265,8 +265,14 @@ class Tags(Limb):
         with self._treant._write:
             # ensure tags are unique (we don't care about order)
             # also they must be strings
-            outtags = set([tag for tag in outtags if
-                           isinstance(tag, string_types)])
+            _outtags = []
+            for tag in outtags:
+                if not isinstance(tag, string_types):
+                    raise ValueError("Only string can be added as tags. Tried "
+                                     "to add '{}' which is '{}'".format(
+                                         tag, type(tag)))
+                _outtags.append(tag)
+            outtags = set(_outtags)
 
             # remove tags already present in metadata from list
             outtags = outtags.difference(set(self._treant._state['tags']))

--- a/src/datreant/core/tests/test_treants.py
+++ b/src/datreant/core/tests/test_treants.py
@@ -335,6 +335,11 @@ class TestTreant(TestTree):
             # complex logic
             assert t.tags[[('marklar', 'bark'), {'dark'}]]
 
+        @pytest.mark.parametrize('tag', (1, 1.2))
+        def test_tags_only_strings(self, treant, tag):
+            with pytest.raises(ValueError):
+                treant.tags.add(tag)
+
     class TestCategories:
         """Test treant categories"""
 


### PR DESCRIPTION
fixes #123 

We now raise a warning with an informative message about the used type and value to ease debugging.