### PR TITLE
Removed inconsistent convenience interfaces; fixes #114

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,13 +19,15 @@ The rules for this file:
 
 API Changes
     * Group object no longer supported; removed (#130)
+    * Removed Tree.treants, Treant.treants, View.bundle, Bundle.view,
+      Tree.discover, Treant.discover; favor use of classes and functions
+      directly for finer control (#114)
 
 
 Enhancements
     
 
 Fixes
-
 
 
 Changes

--- a/src/datreant/core/collections.py
+++ b/src/datreant/core/collections.py
@@ -439,14 +439,6 @@ class View(CollectionMixin):
         return [member.relpath for member in self]
 
     @property
-    def bundle(self):
-        """Obtain a Bundle of all existing Treants among the Trees and Leaves
-        in this View.
-
-        """
-        return Bundle(self, limbs=self.limbs)
-
-    @property
     def exists(self):
         """List giving existence of each member as a boolean.
 
@@ -1059,13 +1051,6 @@ class Bundle(CollectionMixin):
             self._searchtime = value
         else:
             raise TypeError("Must give a number or `None` for searchtime")
-
-    @property
-    def view(self):
-        """Obtain a View giving the Tree for each Treant in this Bundle.
-
-        """
-        return View([member.tree for member in self], limbs=self.limbs)
 
     def globfilter(self, pattern):
         """Return a Bundle of members that match by name the given globbing

--- a/src/datreant/core/tests/test_trees.py
+++ b/src/datreant/core/tests/test_trees.py
@@ -173,31 +173,6 @@ class TestTree(TestVeg):
 
         assert len(tree.hidden) == 2
 
-    def test_treants(self, tree):
-        with pytest.raises(OSError):
-            tree.treants
-
-        # actually make the directory now
-        tree.makedirs()
-
-        assert len(tree.treants) == 0
-
-        # should only give treants immediately present in tree
-        Treant(tree['a/sprout/'])
-        Treant(tree['hide/here/'])
-
-        assert len(tree.treants) == 0
-
-        # should give treants immediately present in tree, including hidden
-        # ones
-        for name in ('thing1/', '.thing2/', 'thing3/'):
-            Treant(tree[name])
-
-        assert len(tree.treants) == 3
-
-    def test_discover(self, tree):
-        pass
-
     def test_equal(self, tree):
         t1 = tree['a dir/']
         t2 = tree['another dir/']

--- a/src/datreant/core/trees.py
+++ b/src/datreant/core/trees.py
@@ -392,19 +392,6 @@ class Tree(Veg):
         from .collections import View
         return View(self.trees + self.leaves + self.hidden, limbs=self.limbs)
 
-    discover = discover
-
-    @property
-    def treants(self):
-        """Bundle of all Treants found within this Tree.
-
-        This does not return a Treant for a bare state file found within this
-        Tree. In effect this gives the same result as ``Bundle(self.trees)``.
-
-        """
-        from .collections import Bundle
-        return Bundle(self.trees + self.hidden.membertrees, limbs=self.limbs)
-
     def glob(self, pattern):
         """Return a View of all child Leaves and Trees matching given globbing
         pattern.


### PR DESCRIPTION
Removed Tree.treants, Treant.treants, View.bundle, Bundle.view,
Tree.discover, Treant.discover; favor use of classes and functions
directly for finer control (#114)