### PR TITLE
Added parents property to View.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ Enhancements
       (Issue #107)
     * Added Bundle.get method, allowing for convenient filtering on tags
       and categories (#144)
+    * Added ``parents`` property to ``View`` (#133)
 
 
 Fixes

--- a/src/datreant/core/collections.py
+++ b/src/datreant/core/collections.py
@@ -152,6 +152,16 @@ class CollectionMixin(object):
             if isinstance(member, Tree):
                 member.draw(depth=depth, hidden=hidden)
 
+    def parents(self):
+        """Return a View of the parent directories for each member.
+
+        Because a View functions as an ordered set, and some members of this
+        collection may share a parent, the View of parents may contain fewer
+        elements than this collection.
+
+        """
+        return View([member.parent for member in self])
+
     @property
     def loc(self):
         """Get a View giving Tree/Leaf at `path` relative to each Tree in

--- a/src/datreant/core/tests/test_collections.py
+++ b/src/datreant/core/tests/test_collections.py
@@ -19,6 +19,19 @@ def return_nothing(treant):
 class CollectionsTests(object):
     """Mixin tests for collections"""
 
+    def test_parents(self, collection, tmpdir):
+        with tmpdir.as_cwd():
+            t1 = dtr.Treant('free-associate/lark')
+            t2 = dtr.Treant('free-associate/hark')
+            t3 = dtr.Treant('characters/linus')
+
+        col = collection(t1, t2, t3)
+
+        assert len(col.parents()) == 2
+        assert 'free-associate' in col.parents().names
+        assert 'linus' not in col.parents().names
+        assert 'characters' in col.parents().names
+
     class TestGetitem(object):
         @pytest.mark.parametrize('slx', (
             [1, 2],


### PR DESCRIPTION
Since ``View`` tries to mirror the properties of ``Tree`` and ``Leaf`` objects as much as possible, giving aggregated results for these, I've added a ``View.parents`` property that gives a ``View`` of parent ``Tree``s for each element in a ``View``.

Since a ``View`` is an ordered set, containing no duplicates, this will give at most as many elements as are present in the original ``View``, but also perhaps fewer. It does allow roundtrips, though, like so:

```python
import datreant.core as dtr

t = dtr.Tree('.')

# will yield a View giving only the ``Tree`` `t` points to
t.children.parents
```

We don't have a test suite at all for ``View``, so perfectly happy to wait to merge this until we have something that tests this functionality.