### PR TITLE
always raise IOError when statefile can't be opened

### DIFF
--- a/src/datreant/core/state.py
+++ b/src/datreant/core/state.py
@@ -126,7 +126,10 @@ class BaseFile(object):
         """Open read-write file descriptor for application of advisory locks.
 
         """
-        self.fd = os.open(self.proxy, os.O_RDWR)
+        try:
+            self.fd = os.open(self.proxy, os.O_RDWR)
+        except OSError as e:
+            raise IOError(e.errno)
 
     def _close_fd(self):
         """Close file descriptor used for application of advisory locks.

--- a/src/datreant/core/state.py
+++ b/src/datreant/core/state.py
@@ -57,7 +57,8 @@ class BaseFile(object):
             if e.errno == 17:
                 pass
             else:
-                raise
+                raise IOError(
+                    e.errno, "can't open file '{}'".format(self.proxy))
 
     def get_location(self):
         """Get File basedir.

--- a/src/datreant/core/tests/test_treants.py
+++ b/src/datreant/core/tests/test_treants.py
@@ -514,5 +514,5 @@ class TestReadOnly:
 
         assert '72' in c.tags
 
-        with pytest.raises(OSError):
+        with pytest.raises(IOError):
             c.tags.add('yet another')


### PR DESCRIPTION
https://github.com/datreant/MDSynthesis/pull/70

This means should ensure an IOError for all python versions.